### PR TITLE
Bugfix for readBitInt and bitVal corruption bug

### DIFF
--- a/src/lib/parser/Reader.js
+++ b/src/lib/parser/Reader.js
@@ -87,6 +87,7 @@ class Reader {
     }
 
     while (count > this.bitCount) {
+      this.bitVal &= (1 << this.bitCount) - 1;
       this.bitVal |= this.nextByte() << this.bitCount;
       this.bitCount += 8;
     }


### PR DESCRIPTION
In some cases, bitVal will contain "garbage" (e.g. unrelated bits set, regardless, beyond bitCount). This causes corruption.

Added code to clean bitVal to ensure only the relevant bitCount bits are set.

Before this change, match ID 8322897688 (and many others) fail to parse properly.